### PR TITLE
Update Mercedes-Benz A-180 generations: Added generational data from Wikipedia

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
-# Model make
+# Mercedes-Benz A-180
+
+This repository contains signal set configurations for the Mercedes-Benz A-180, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Mercedes-Benz A-180.
+
+The A-180 is a trim level/engine variant of the Mercedes-Benz A-Class, available across four generations (W168, W169, W176, W177) from 1997 to present. It has been offered as both a hatchback and sedan body style, with various petrol and diesel engine options.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.
 

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,0 +1,36 @@
+references:
+  - "https://en.wikipedia.org/wiki/Mercedes-Benz_A-Class"
+
+generations:
+  - name: "First Generation (W168)"
+    start_year: 1997
+    end_year: 2004
+    description: "First generation A-Class introduced at Frankfurt Motor Show. Front-wheel drive layout with unusual tall but short body. The A-180 designation was not used in this generation - models included A 140, A 160, A 190, and A 210 Evolution. Facelifted in February 2001 with minor alterations to headlights, bumpers, and longer wheelbase version."
+    platform: "W168"
+    body_styles:
+      - "5-door hatchback"
+
+  - name: "Second Generation (W169)"
+    start_year: 2004
+    end_year: 2012
+    description: "Second generation A-Class with improved safety features including adaptive airbags and active head restraints. The A-180 was introduced as a trim level, particularly in Japan where A 170 was renamed to A 180 in August 2009. Also available as A 180 CDI diesel variant. Facelifted in 2008 with redesigned fascias and lights."
+    platform: "W169"
+    body_styles:
+      - "5-door hatchback"
+      - "3-door coupe"
+
+  - name: "Third Generation (W176)"
+    start_year: 2012
+    end_year: 2018
+    description: "Third generation A-Class reclassified as subcompact executive/C-segment. Built on Mercedes-Benz MFA platform. The A-180 was available as an Urban trim level. Facelifted in Q3 2015 with updated lights and technology."
+    platform: "W176"
+    body_styles:
+      - "5-door hatchback"
+
+  - name: "Fourth Generation (W177)"
+    start_year: 2018
+    description: "Fourth generation A-Class launched in March 2018, available as 5-door hatchback (W177) and 4-door sedan (V177). The A-180 is available as a Progressive trim level. First generation offered in United States and Canada."
+    platform: "W177"
+    body_styles:
+      - "5-door hatchback"
+      - "4-door sedan"


### PR DESCRIPTION
- Created generations.yaml with four generations (W168, W169, W176, W177)
- Documented production years: 1997-present across all generations
- Included A-180 trim level variants and body styles (hatchback/sedan)
- Noted facelift periods for Gen 1 (2001), Gen 2 (2008), and Gen 3 (2015)
- Updated README.md with vehicle description and standard template
- Reference: https://en.wikipedia.org/wiki/Mercedes-Benz_A-Class
